### PR TITLE
  Added the missing storage.delete_download(id) call:

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1208,10 +1208,13 @@ impl DownloadEngine {
             }
         }
 
-        // Clean up saved segments from storage
+        // Clean up saved segments and download record from storage
         if let Some(ref storage) = self.storage {
             if let Err(e) = storage.delete_segments(id).await {
                 tracing::debug!("Failed to clean up segments for cancelled download {}: {}", id, e);
+            }
+            if let Err(e) = storage.delete_download(id).await {
+                tracing::debug!("Failed to delete download record for {}: {}", id, e);
             }
         }
 


### PR DESCRIPTION
What was wrong

  The cancel() method in src/engine.rs:1211-1219 called storage.delete_segments(id) but never called storage.delete_download(id). This left the download record in the SQLite database, causing cancelled downloads to reappear after application restart.

  The fix

  Added the missing storage.delete_download(id) call:

  // Clean up saved segments and download record from storage
  if let Some(ref storage) = self.storage {
      if let Err(e) = storage.delete_segments(id).await {
          tracing::debug!("Failed to clean up segments for cancelled download {}: {}", id, e);
      }
      if let Err(e) = storage.delete_download(id).await {
          tracing::debug!("Failed to delete download record for {}: {}", id, e);
      }
  }
