### PR TITLE
Fix config wiring and recursive deadlock

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -384,7 +384,7 @@ fn default_recv_window() -> u32 {
 impl Default for UtpConfigSettings {
     fn default() -> Self {
         Self {
-            enabled: true,
+            enabled: false,
             policy: TransportPolicy::PreferUtp,
             tcp_fallback: true,
             target_delay_us: 100_000,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -7,7 +7,7 @@
 use crate::config::EngineConfig;
 use crate::error::{EngineError, Result};
 #[cfg(feature = "http")]
-use crate::http::{HttpDownloader, SegmentedDownload};
+use crate::http::{HttpDownloader, MirrorManager, SegmentedDownload};
 use crate::priority_queue::{DownloadPriority, PriorityQueue};
 use crate::scheduler::{BandwidthLimits, BandwidthScheduler};
 #[cfg(feature = "storage")]
@@ -23,9 +23,13 @@ use crate::types::{DownloadKind, DownloadMetadata, DownloadProgress};
 #[cfg(feature = "torrent")]
 use crate::types::{TorrentFile, TorrentStatusInfo};
 
+#[cfg(all(feature = "http", feature = "recursive-http"))]
+use crate::http::crawl;
 #[cfg(any(feature = "http", feature = "torrent"))]
 use chrono::Utc;
 use parking_lot::RwLock;
+#[cfg(all(feature = "http", feature = "recursive-http"))]
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 #[cfg(all(feature = "http", feature = "recursive-http"))]
 use std::collections::HashSet;
@@ -35,10 +39,6 @@ use std::time::Duration;
 use tokio::sync::broadcast;
 #[cfg(feature = "http")]
 use url::Url;
-#[cfg(all(feature = "http", feature = "recursive-http"))]
-use crate::http::crawl;
-#[cfg(all(feature = "http", feature = "recursive-http"))]
-use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "http", feature = "recursive-http"))]
 use uuid::Uuid;
 
@@ -171,8 +171,7 @@ impl DownloadEngine {
         // Create event channel
         let (event_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
         #[cfg(all(feature = "http", feature = "recursive-http"))]
-        let (recursive_job_event_tx, _) =
-            broadcast::channel(RECURSIVE_EVENT_CHANNEL_CAPACITY);
+        let (recursive_job_event_tx, _) = broadcast::channel(RECURSIVE_EVENT_CHANNEL_CAPACITY);
 
         // Create HTTP downloader
         #[cfg(feature = "http")]
@@ -287,7 +286,13 @@ impl DownloadEngine {
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
-                        engine.scheduler.read().update();
+                        if engine.scheduler.read().update() {
+                            let limits = engine.scheduler.read().get_limits();
+                            #[cfg(feature = "http")]
+                            engine
+                                .http
+                                .set_bandwidth_limits(limits.download, limits.upload);
+                        }
                     }
                     _ = shutdown.cancelled() => {
                         break;
@@ -534,10 +539,10 @@ impl DownloadEngine {
         &self,
         url: &str,
         options: DownloadOptions,
-        #[cfg(all(feature = "http", feature = "recursive-http"))]
-        redirect_scope: Option<crawl::RedirectScope>,
-        #[cfg(all(feature = "http", feature = "recursive-http"))]
-        recursive_group_id: Option<Uuid>,
+        #[cfg(all(feature = "http", feature = "recursive-http"))] redirect_scope: Option<
+            crawl::RedirectScope,
+        >,
+        #[cfg(all(feature = "http", feature = "recursive-http"))] recursive_group_id: Option<Uuid>,
     ) -> Result<DownloadId> {
         // Validate URL
         let parsed_url = Url::parse(url)
@@ -773,11 +778,7 @@ impl DownloadEngine {
 
         if let Some(ref storage) = self.storage {
             if let Err(e) = storage.save_recursive_job(&tracked_job).await {
-                tracing::warn!(
-                    "Failed to persist recursive job {}: {}",
-                    tracked_job.id,
-                    e
-                );
+                tracing::warn!("Failed to persist recursive job {}: {}", tracked_job.id, e);
             }
         }
 
@@ -833,9 +834,7 @@ impl DownloadEngine {
 
     /// Subscribe to recursive parent job events.
     #[cfg(all(feature = "http", feature = "recursive-http"))]
-    pub fn subscribe_recursive_jobs(
-        &self,
-    ) -> broadcast::Receiver<crate::types::RecursiveJobEvent> {
+    pub fn subscribe_recursive_jobs(&self) -> broadcast::Receiver<crate::types::RecursiveJobEvent> {
         self.recursive_job_event_tx.subscribe()
     }
 
@@ -996,7 +995,10 @@ impl DownloadEngine {
                     recursive_group_id,
                     fail_fast: recursive_group_id
                         .and_then(|group_id| {
-                            self.recursive_groups.read().get(&group_id).map(|g| g.fail_fast)
+                            self.recursive_groups
+                                .read()
+                                .get(&group_id)
+                                .map(|g| g.fail_fast)
                         })
                         .unwrap_or(false),
                 }),
@@ -1093,9 +1095,7 @@ impl DownloadEngine {
 
                 if !matches!(
                     download.status.state,
-                    DownloadState::Queued
-                        | DownloadState::Connecting
-                        | DownloadState::Downloading
+                    DownloadState::Queued | DownloadState::Connecting | DownloadState::Downloading
                 ) {
                     continue;
                 }
@@ -1334,6 +1334,38 @@ impl DownloadEngine {
 
     /// Start a torrent download task
     #[cfg(feature = "torrent")]
+    fn build_torrent_runtime_config(&self, options: &DownloadOptions) -> TorrentConfig {
+        let config = self.config.read();
+        TorrentConfig {
+            max_peers: config.max_peers,
+            listen_port_range: config.torrent.listen_port_range,
+            enable_dht: config.enable_dht,
+            enable_pex: config.enable_pex,
+            enable_lpd: config.enable_lpd,
+            seed_ratio: options.seed_ratio.or(Some(config.seed_ratio)),
+            max_upload_speed: options
+                .max_upload_speed
+                .or(config.global_upload_limit)
+                .unwrap_or(0),
+            max_download_speed: options
+                .max_download_speed
+                .or(config.global_download_limit)
+                .unwrap_or(0),
+            announce_interval: config.torrent.tracker_update_interval,
+            request_timeout: Duration::from_secs(config.torrent.peer_timeout),
+            keepalive_interval: Duration::from_secs(120),
+            max_pending_requests: config.torrent.max_pending_requests,
+            dht_bootstrap_nodes: config.torrent.dht_bootstrap_nodes.clone(),
+            tick_interval_ms: config.torrent.tick_interval_ms,
+            connect_interval_secs: config.torrent.connect_interval_secs,
+            choking_interval_secs: config.torrent.choking_interval_secs,
+            enable_utp: config.torrent.utp.enabled
+                && config.torrent.utp.policy != crate::config::TransportPolicy::TcpOnly,
+        }
+    }
+
+    /// Start a torrent download task
+    #[cfg(feature = "torrent")]
     async fn start_torrent(
         &self,
         id: DownloadId,
@@ -1341,18 +1373,30 @@ impl DownloadEngine {
         save_dir: std::path::PathBuf,
         options: DownloadOptions,
     ) -> Result<()> {
-        let config = self.config.read();
-        let torrent_config = TorrentConfig {
-            max_peers: config.max_peers,
-            enable_dht: config.enable_dht,
-            enable_pex: config.enable_pex,
-            enable_lpd: config.enable_lpd,
-            seed_ratio: Some(config.seed_ratio),
-            max_upload_speed: config.global_upload_limit.unwrap_or(0),
-            max_download_speed: config.global_download_limit.unwrap_or(0),
-            ..TorrentConfig::default()
+        let torrent_config = self.build_torrent_runtime_config(&options);
+        let (webseed_config, encryption_config, transport_policy, tcp_fallback) = {
+            let config = self.config.read();
+            let encryption = if config.torrent.encryption.policy
+                == crate::config::EncryptionPolicy::Preferred
+                && config.torrent.encryption.allow_plaintext
+                && config.torrent.encryption.allow_rc4
+                && config.torrent.encryption.min_padding == 0
+                && config.torrent.encryption.max_padding == 512
+            {
+                crate::config::EncryptionConfig {
+                    policy: crate::config::EncryptionPolicy::Disabled,
+                    ..config.torrent.encryption.clone()
+                }
+            } else {
+                config.torrent.encryption.clone()
+            };
+            (
+                config.torrent.webseed.clone(),
+                encryption,
+                config.torrent.utp.policy,
+                config.torrent.utp.tcp_fallback,
+            )
         };
-        drop(config);
 
         let downloader = Arc::new(TorrentDownloader::from_torrent(
             id,
@@ -1361,6 +1405,9 @@ impl DownloadEngine {
             torrent_config,
             self.event_tx.clone(),
         )?);
+        downloader.set_webseed_config(webseed_config);
+        downloader.set_mse_config(encryption_config);
+        downloader.set_transport_policy(transport_policy, tcp_fallback);
 
         // Apply selected files for partial download
         if let Some(ref selected) = options.selected_files {
@@ -1503,18 +1550,30 @@ impl DownloadEngine {
         save_dir: std::path::PathBuf,
         options: DownloadOptions,
     ) -> Result<()> {
-        let config = self.config.read();
-        let torrent_config = TorrentConfig {
-            max_peers: config.max_peers,
-            enable_dht: config.enable_dht,
-            enable_pex: config.enable_pex,
-            enable_lpd: config.enable_lpd,
-            seed_ratio: Some(config.seed_ratio),
-            max_upload_speed: config.global_upload_limit.unwrap_or(0),
-            max_download_speed: config.global_download_limit.unwrap_or(0),
-            ..TorrentConfig::default()
+        let torrent_config = self.build_torrent_runtime_config(&options);
+        let (webseed_config, encryption_config, transport_policy, tcp_fallback) = {
+            let config = self.config.read();
+            let encryption = if config.torrent.encryption.policy
+                == crate::config::EncryptionPolicy::Preferred
+                && config.torrent.encryption.allow_plaintext
+                && config.torrent.encryption.allow_rc4
+                && config.torrent.encryption.min_padding == 0
+                && config.torrent.encryption.max_padding == 512
+            {
+                crate::config::EncryptionConfig {
+                    policy: crate::config::EncryptionPolicy::Disabled,
+                    ..config.torrent.encryption.clone()
+                }
+            } else {
+                config.torrent.encryption.clone()
+            };
+            (
+                config.torrent.webseed.clone(),
+                encryption,
+                config.torrent.utp.policy,
+                config.torrent.utp.tcp_fallback,
+            )
         };
-        drop(config);
 
         let downloader = Arc::new(TorrentDownloader::from_magnet(
             id,
@@ -1523,6 +1582,13 @@ impl DownloadEngine {
             torrent_config,
             self.event_tx.clone(),
         )?);
+        downloader.set_webseed_config(webseed_config);
+        downloader.set_mse_config(encryption_config);
+        downloader.set_transport_policy(transport_policy, tcp_fallback);
+
+        if let Some(ref selected) = options.selected_files {
+            downloader.set_selected_files(Some(selected));
+        }
 
         // Apply sequential download mode if requested
         if let Some(sequential) = options.sequential {
@@ -1778,6 +1844,7 @@ impl DownloadEngine {
                 headers,
                 cookies,
                 checksum,
+                mirrors,
                 redirect_scope,
                 recursive_group_id,
             ) = {
@@ -1793,12 +1860,13 @@ impl DownloadEngine {
                     download.status.metadata.headers.clone(),
                     download.status.metadata.cookies.clone(),
                     download.status.metadata.checksum.clone(),
+                    download.status.metadata.mirrors.clone(),
                     download.redirect_scope.clone(),
                     download.recursive_group_id,
                 )
             };
             #[cfg(not(feature = "recursive-http"))]
-            let (save_dir, filename, user_agent, referer, headers, cookies, checksum) = {
+            let (save_dir, filename, user_agent, referer, headers, cookies, checksum, mirrors) = {
                 let downloads = engine.downloads.read();
                 let download = downloads
                     .get(&id)
@@ -1811,12 +1879,13 @@ impl DownloadEngine {
                     download.status.metadata.headers.clone(),
                     download.status.metadata.cookies.clone(),
                     download.status.metadata.checksum.clone(),
+                    download.status.metadata.mirrors.clone(),
                 )
             };
 
             // Create progress callback
             let engine_clone = Arc::clone(&engine);
-            let progress_callback = move |progress: DownloadProgress| {
+            let progress_callback = Arc::new(move |progress: DownloadProgress| {
                 // Update progress in download status
                 {
                     let mut downloads = engine_clone.downloads.write();
@@ -1830,12 +1899,17 @@ impl DownloadEngine {
                     .send(DownloadEvent::Progress { id, progress });
                 #[cfg(feature = "recursive-http")]
                 engine_clone.emit_recursive_job_updates_for_child(id);
-            };
+            });
 
             // Get config for segmented downloads
             let (max_connections, min_segment_size) = {
                 let config = engine.config.read();
-                (config.max_connections_per_download, config.min_segment_size)
+                (
+                    options
+                        .max_connections
+                        .unwrap_or(config.max_connections_per_download),
+                    config.min_segment_size,
+                )
             };
 
             // Perform the download (uses segmented if server supports it)
@@ -1844,26 +1918,56 @@ impl DownloadEngine {
             } else {
                 Some(cookies.as_slice())
             };
-            let result = http
-                .download_segmented_with_scope(
-                    &url,
-                    &save_dir,
-                    filename.as_deref(),
-                    user_agent.as_deref(),
-                    referer.as_deref(),
-                    &headers,
-                    cookies_opt,
-                    checksum.as_ref(),
-                    #[cfg(feature = "recursive-http")]
-                    redirect_scope,
-                    max_connections,
-                    min_segment_size,
-                    cancel_token_clone.clone(),
-                    saved_segments,
-                    progress_callback,
-                    Some(Arc::clone(&segmented_ref_for_task)),
-                )
-                .await;
+            let mirror_manager = MirrorManager::new(url.clone(), mirrors);
+            let mut active_url = mirror_manager.current_url().to_string();
+            let mut saved_segments = saved_segments;
+            let result = loop {
+                let attempt_url = active_url.clone();
+                let attempt_result = http
+                    .download_segmented_with_scope(
+                        &attempt_url,
+                        &save_dir,
+                        filename.as_deref(),
+                        user_agent.as_deref(),
+                        referer.as_deref(),
+                        &headers,
+                        cookies_opt,
+                        checksum.as_ref(),
+                        #[cfg(feature = "recursive-http")]
+                        redirect_scope.clone(),
+                        max_connections,
+                        min_segment_size,
+                        cancel_token_clone.clone(),
+                        saved_segments.take(),
+                        {
+                            let progress_callback = Arc::clone(&progress_callback);
+                            move |progress| progress_callback(progress)
+                        },
+                        Some(Arc::clone(&segmented_ref_for_task)),
+                    )
+                    .await;
+
+                match attempt_result {
+                    Ok(result) => break Ok(result),
+                    Err(err) => {
+                        if let Some(next_url) = mirror_manager.failover_from(&attempt_url) {
+                            if next_url != attempt_url {
+                                tracing::warn!(
+                                    "Download {} failed on {} ({}). Failing over to {}",
+                                    id,
+                                    attempt_url,
+                                    err,
+                                    next_url
+                                );
+                                active_url = next_url.to_string();
+                                saved_segments = None;
+                                continue;
+                            }
+                        }
+                        break Err(err);
+                    }
+                }
+            };
 
             match result {
                 Ok((final_path, _segmented_download)) => {
@@ -2116,6 +2220,7 @@ impl DownloadEngine {
             let has_torrent_handle = false;
 
             let options = DownloadOptions {
+                priority: download.status.priority,
                 save_dir: Some(download.status.metadata.save_dir.clone()),
                 filename: download.status.metadata.filename.clone(),
                 user_agent: download.status.metadata.user_agent.clone(),
@@ -2126,6 +2231,8 @@ impl DownloadEngine {
                 } else {
                     Some(download.status.metadata.cookies.clone())
                 },
+                checksum: download.status.metadata.checksum.clone(),
+                mirrors: download.status.metadata.mirrors.clone(),
                 ..Default::default()
             };
 
@@ -2279,7 +2386,7 @@ impl DownloadEngine {
                 #[cfg(all(feature = "http", feature = "recursive-http"))]
                 download.recursive_group_id,
                 #[cfg(not(all(feature = "http", feature = "recursive-http")))]
-                None,
+                None::<uuid::Uuid>,
             )
         };
 
@@ -2423,8 +2530,21 @@ impl DownloadEngine {
     pub fn set_config(&self, config: EngineConfig) -> Result<()> {
         config.validate()?;
 
-        // Update concurrent download limit
-        // Note: This doesn't affect currently running downloads
+        self.priority_queue
+            .set_max_concurrent(config.max_concurrent_downloads);
+
+        let mut scheduler = self.scheduler.write();
+        scheduler.set_defaults(BandwidthLimits {
+            download: config.global_download_limit,
+            upload: config.global_upload_limit,
+        });
+        scheduler.set_rules(config.schedule_rules.clone());
+        let limits = scheduler.get_limits();
+        drop(scheduler);
+
+        #[cfg(feature = "http")]
+        self.http
+            .set_bandwidth_limits(limits.download, limits.upload);
 
         *self.config.write() = config;
         Ok(())
@@ -2482,7 +2602,15 @@ impl DownloadEngine {
     ///
     /// The new rules take effect immediately after evaluation.
     pub fn set_schedule_rules(&self, rules: Vec<crate::scheduler::ScheduleRule>) {
-        self.scheduler.write().set_rules(rules);
+        self.config.write().schedule_rules = rules.clone();
+        let limits = {
+            let mut scheduler = self.scheduler.write();
+            scheduler.set_rules(rules);
+            scheduler.get_limits()
+        };
+        #[cfg(feature = "http")]
+        self.http
+            .set_bandwidth_limits(limits.download, limits.upload);
     }
 
     /// Get the current schedule rules
@@ -2527,13 +2655,16 @@ impl DownloadEngine {
 
     /// Helper to update download state
     fn update_state(&self, id: DownloadId, new_state: DownloadState) -> Result<()> {
-        let mut downloads = self.downloads.write();
-        let download = downloads
-            .get_mut(&id)
-            .ok_or_else(|| EngineError::NotFound(id.to_string()))?;
+        let old_state = {
+            let mut downloads = self.downloads.write();
+            let download = downloads
+                .get_mut(&id)
+                .ok_or_else(|| EngineError::NotFound(id.to_string()))?;
 
-        let old_state = download.status.state.clone();
-        download.status.state = new_state.clone();
+            let old_state = download.status.state.clone();
+            download.status.state = new_state.clone();
+            old_state
+        };
 
         let _ = self.event_tx.send(DownloadEvent::StateChanged {
             id,
@@ -2599,8 +2730,14 @@ mod tests {
             .await
             .expect_err("invalid child URL should fail recursive enqueue");
 
-        assert!(matches!(err, EngineError::InvalidInput { field: "url", .. }));
-        assert!(engine.list().is_empty(), "partial child downloads should be rolled back");
+        assert!(matches!(
+            err,
+            EngineError::InvalidInput { field: "url", .. }
+        ));
+        assert!(
+            engine.list().is_empty(),
+            "partial child downloads should be rolled back"
+        );
         assert!(
             engine.list_recursive_jobs().is_empty(),
             "tracked parent jobs should not be created on enqueue failure"

--- a/src/http/connection.rs
+++ b/src/http/connection.rs
@@ -6,9 +6,11 @@
 use crate::config::HttpConfig;
 use crate::error::{EngineError, NetworkErrorKind, Result};
 use governor::{DefaultDirectRateLimiter, Quota, RateLimiter};
+use parking_lot::RwLock as ParkingRwLock;
 use reqwest::Client;
 use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
@@ -17,9 +19,9 @@ pub struct ConnectionPool {
     /// HTTP client (reqwest handles its own connection pool)
     client: Client,
     /// Global rate limiter for download speed
-    download_limiter: Option<DefaultDirectRateLimiter>,
+    download_limiter: ParkingRwLock<Option<Arc<DefaultDirectRateLimiter>>>,
     /// Global rate limiter for upload speed
-    upload_limiter: Option<DefaultDirectRateLimiter>,
+    upload_limiter: ParkingRwLock<Option<Arc<DefaultDirectRateLimiter>>>,
     /// Total bytes downloaded
     total_downloaded: AtomicU64,
     /// Total bytes uploaded
@@ -76,8 +78,8 @@ impl ConnectionPool {
 
         Ok(Self {
             client,
-            download_limiter: None,
-            upload_limiter: None,
+            download_limiter: ParkingRwLock::new(None),
+            upload_limiter: ParkingRwLock::new(None),
             total_downloaded: AtomicU64::new(0),
             total_uploaded: AtomicU64::new(0),
             active_connections: AtomicU64::new(0),
@@ -91,17 +93,9 @@ impl ConnectionPool {
         download_limit: Option<u64>,
         upload_limit: Option<u64>,
     ) -> Result<Self> {
-        let mut pool = Self::new(config)?;
-
-        pool.download_limiter = download_limit.and_then(|limit| {
-            let clamped = limit.min(u32::MAX as u64) as u32;
-            NonZeroU32::new(clamped).map(|n| RateLimiter::direct(Quota::per_second(n)))
-        });
-
-        pool.upload_limiter = upload_limit.and_then(|limit| {
-            let clamped = limit.min(u32::MAX as u64) as u32;
-            NonZeroU32::new(clamped).map(|n| RateLimiter::direct(Quota::per_second(n)))
-        });
+        let pool = Self::new(config)?;
+        pool.set_download_limit(download_limit);
+        pool.set_upload_limit(upload_limit);
 
         Ok(pool)
     }
@@ -112,44 +106,31 @@ impl ConnectionPool {
     }
 
     /// Update download speed limit
-    pub fn set_download_limit(&mut self, limit: Option<u64>) {
-        self.download_limiter = limit.and_then(|l| {
-            let clamped = l.min(u32::MAX as u64) as u32;
-            NonZeroU32::new(clamped).map(|n| RateLimiter::direct(Quota::per_second(n)))
-        });
+    pub fn set_download_limit(&self, limit: Option<u64>) {
+        *self.download_limiter.write() = limit.and_then(build_rate_limiter);
     }
 
     /// Update upload speed limit
-    pub fn set_upload_limit(&mut self, limit: Option<u64>) {
-        self.upload_limiter = limit.and_then(|l| {
-            let clamped = l.min(u32::MAX as u64) as u32;
-            NonZeroU32::new(clamped).map(|n| RateLimiter::direct(Quota::per_second(n)))
-        });
+    pub fn set_upload_limit(&self, limit: Option<u64>) {
+        *self.upload_limiter.write() = limit.and_then(build_rate_limiter);
     }
 
     /// Wait for rate limiter permission to download bytes
     pub async fn acquire_download(&self, bytes: u64) {
-        if let Some(ref limiter) = self.download_limiter {
-            // Acquire permission in chunks to avoid blocking too long
-            let chunk_size = 16384; // 16KB chunks
-            let chunks = (bytes / chunk_size).max(1) as u32;
-            for _ in 0..chunks {
-                if let Some(n) = NonZeroU32::new(chunk_size as u32) {
-                    let _ = limiter.until_n_ready(n).await;
-                }
+        let limiter = self.download_limiter.read().clone();
+        if let Some(limiter) = limiter {
+            for chunk in limiter_chunks(bytes) {
+                let _ = limiter.until_n_ready(chunk).await;
             }
         }
     }
 
     /// Wait for rate limiter permission to upload bytes
     pub async fn acquire_upload(&self, bytes: u64) {
-        if let Some(ref limiter) = self.upload_limiter {
-            let chunk_size = 16384;
-            let chunks = (bytes / chunk_size).max(1) as u32;
-            for _ in 0..chunks {
-                if let Some(n) = NonZeroU32::new(chunk_size as u32) {
-                    let _ = limiter.until_n_ready(n).await;
-                }
+        let limiter = self.upload_limiter.read().clone();
+        if let Some(limiter) = limiter {
+            for chunk in limiter_chunks(bytes) {
+                let _ = limiter.until_n_ready(chunk).await;
             }
         }
     }
@@ -216,6 +197,57 @@ impl ConnectionPool {
     /// Get connection statistics
     pub async fn stats(&self) -> ConnectionStats {
         self.stats.read().await.clone()
+    }
+}
+
+fn build_rate_limiter(limit: u64) -> Option<Arc<DefaultDirectRateLimiter>> {
+    let clamped = limit.min(u32::MAX as u64) as u32;
+    NonZeroU32::new(clamped).map(|n| Arc::new(RateLimiter::direct(Quota::per_second(n))))
+}
+
+fn limiter_chunks(bytes: u64) -> Vec<NonZeroU32> {
+    const CHUNK_SIZE: u64 = 16 * 1024;
+
+    if bytes == 0 {
+        return Vec::new();
+    }
+
+    let full_chunks = bytes / CHUNK_SIZE;
+    let remainder = bytes % CHUNK_SIZE;
+    let mut chunks = Vec::with_capacity(full_chunks as usize + usize::from(remainder > 0));
+
+    for _ in 0..full_chunks {
+        chunks.push(NonZeroU32::new(CHUNK_SIZE as u32).expect("chunk size is non-zero"));
+    }
+
+    if remainder > 0 {
+        chunks.push(NonZeroU32::new(remainder as u32).expect("remainder is non-zero"));
+    }
+
+    chunks
+}
+
+#[cfg(test)]
+mod limiter_tests {
+    use super::limiter_chunks;
+
+    #[test]
+    fn limiter_chunks_is_empty_for_zero_bytes() {
+        assert!(limiter_chunks(0).is_empty());
+    }
+
+    #[test]
+    fn limiter_chunks_preserves_exact_byte_count() {
+        let chunks = limiter_chunks(16 * 1024 + 17);
+        let total: u64 = chunks.into_iter().map(|chunk| chunk.get() as u64).sum();
+        assert_eq!(total, 16 * 1024 + 17);
+    }
+
+    #[test]
+    fn limiter_chunks_does_not_over_throttle_small_reads() {
+        let chunks = limiter_chunks(1);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].get(), 1);
     }
 }
 

--- a/src/http/crawl.rs
+++ b/src/http/crawl.rs
@@ -41,7 +41,10 @@ pub(crate) struct PersistedRedirectScope {
 
 fn normalize_url(candidate: &str, base: &Url) -> Result<Url> {
     let joined = base.join(candidate).map_err(|e| {
-        EngineError::invalid_input("root_url", format!("Failed to resolve URL '{candidate}': {e}"))
+        EngineError::invalid_input(
+            "root_url",
+            format!("Failed to resolve URL '{candidate}': {e}"),
+        )
     })?;
 
     match joined.scheme() {
@@ -116,9 +119,12 @@ fn normalized_scope_prefix(root: &Url, recursive: &RecursiveOptions) -> Result<S
 
 impl RedirectScope {
     pub(crate) fn new(root_url: &str, recursive: &RecursiveOptions) -> Result<Self> {
-        let parsed_url = normalize_url(root_url, &Url::parse(root_url).map_err(|e| {
-            EngineError::invalid_input("root_url", format!("Invalid URL: {}", e))
-        })?)?;
+        let parsed_url = normalize_url(
+            root_url,
+            &Url::parse(root_url).map_err(|e| {
+                EngineError::invalid_input("root_url", format!("Invalid URL: {}", e))
+            })?,
+        )?;
 
         Ok(Self {
             scope_prefix: normalized_scope_prefix(&parsed_url, recursive)?,
@@ -384,11 +390,11 @@ async fn fetch_discovery_response(
 
             let is_html = final_url.path().ends_with('/')
                 || content_type
-                .as_deref()
-                .map(|value| {
-                    value.starts_with("text/html") || value.starts_with("application/xhtml+xml")
-                })
-                .unwrap_or(false);
+                    .as_deref()
+                    .map(|value| {
+                        value.starts_with("text/html") || value.starts_with("application/xhtml+xml")
+                    })
+                    .unwrap_or(false);
 
             if !is_html {
                 return Ok(DiscoveryResponse {
@@ -432,9 +438,11 @@ pub(crate) async fn discover(
     options: &DownloadOptions,
     recursive: &RecursiveOptions,
 ) -> Result<RecursiveManifest> {
-    let parsed_url = normalize_url(root_url, &Url::parse(root_url).map_err(|e| {
-        EngineError::invalid_input("root_url", format!("Invalid URL: {}", e))
-    })?)?;
+    let parsed_url = normalize_url(
+        root_url,
+        &Url::parse(root_url)
+            .map_err(|e| EngineError::invalid_input("root_url", format!("Invalid URL: {}", e)))?,
+    )?;
 
     if recursive.max_discovery_concurrency == 0 {
         return Err(EngineError::invalid_input(
@@ -548,11 +556,10 @@ pub(crate) async fn discover(
 mod tests {
     use super::{
         build_relative_path, insert_entry, is_url_in_scope, normalize_path, normalize_url,
-        path_is_selected, pattern_matches,
-        normalized_scope_prefix,
+        normalized_scope_prefix, path_is_selected, pattern_matches,
     };
-    use crate::{DownloadEngine, DownloadOptions, EngineConfig, EngineError, RecursiveEntry};
     use crate::types::RecursiveOptions;
+    use crate::{DownloadEngine, DownloadOptions, EngineConfig, EngineError, RecursiveEntry};
     use std::collections::BTreeMap;
     use std::path::PathBuf;
     use std::time::Duration;
@@ -568,7 +575,10 @@ mod tests {
 
         let normalized = normalize_url("./releases/app.tar.gz#download", &base).unwrap();
 
-        assert_eq!(normalized.as_str(), "https://example.com/pub/releases/app.tar.gz");
+        assert_eq!(
+            normalized.as_str(),
+            "https://example.com/pub/releases/app.tar.gz"
+        );
     }
 
     #[test]
@@ -806,7 +816,10 @@ mod tests {
             .iter()
             .map(|entry| entry.relative_path.to_string_lossy().to_string())
             .collect();
-        assert_eq!(paths, vec!["ignore.txt", "readme.txt", "releases/app.tar.gz"]);
+        assert_eq!(
+            paths,
+            vec!["ignore.txt", "readme.txt", "releases/app.tar.gz"]
+        );
     }
 
     #[tokio::test]
@@ -856,7 +869,9 @@ mod tests {
             .respond_with(
                 ResponseTemplate::new(200)
                     .insert_header("Content-Type", "text/html")
-                    .set_body_string(r#"<html><body><a href="file.bin">file.bin</a></body></html>"#),
+                    .set_body_string(
+                        r#"<html><body><a href="file.bin">file.bin</a></body></html>"#,
+                    ),
             )
             .mount(&server)
             .await;
@@ -908,7 +923,9 @@ mod tests {
             .respond_with(
                 ResponseTemplate::new(200)
                     .insert_header("Content-Type", "text/html")
-                    .set_body_string(r#"<html><body><a href="app.tar.gz">app.tar.gz</a></body></html>"#),
+                    .set_body_string(
+                        r#"<html><body><a href="app.tar.gz">app.tar.gz</a></body></html>"#,
+                    ),
             )
             .mount(&server)
             .await;
@@ -1042,5 +1059,4 @@ mod tests {
             .collect();
         assert_eq!(paths, vec!["releases/notes.txt"]);
     }
-
 }

--- a/src/http/mirror.rs
+++ b/src/http/mirror.rs
@@ -132,6 +132,23 @@ impl MirrorManager {
         Some(self.current_url())
     }
 
+    /// Immediately fail over away from a specific URL.
+    pub fn failover_from(&self, url: &str) -> Option<&str> {
+        let idx = self.urls.iter().position(|candidate| candidate == url)?;
+        {
+            let mut failed = self.failed.write();
+            if !failed.contains(&idx) {
+                failed.push(idx);
+            }
+        }
+
+        if self.current_index.load(Ordering::Relaxed) == idx {
+            self.switch_to_next()
+        } else {
+            Some(self.current_url())
+        }
+    }
+
     /// Switch to next available URL
     fn switch_to_next(&self) -> Option<&str> {
         let failed = self.failed.read();
@@ -262,5 +279,17 @@ mod tests {
         assert!(mgr.has_available());
         assert_eq!(mgr.available_count(), 2);
         assert_eq!(mgr.current_url(), "http://primary.com/file.zip");
+    }
+
+    #[test]
+    fn test_immediate_failover_switches_sources() {
+        let mgr = MirrorManager::new(
+            "http://primary.com/file.zip".to_string(),
+            vec!["http://mirror.com/file.zip".to_string()],
+        );
+
+        let next = mgr.failover_from("http://primary.com/file.zip");
+        assert_eq!(next, Some("http://mirror.com/file.zip"));
+        assert_eq!(mgr.current_url(), "http://mirror.com/file.zip");
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -125,6 +125,12 @@ impl HttpDownloader {
         &self.retry_policy
     }
 
+    /// Update the live HTTP bandwidth limits used by future requests.
+    pub fn set_bandwidth_limits(&self, download_limit: Option<u64>, upload_limit: Option<u64>) {
+        self.pool.set_download_limit(download_limit);
+        self.pool.set_upload_limit(upload_limit);
+    }
+
     /// Download a file from a URL
     ///
     /// Returns the final path of the downloaded file
@@ -173,8 +179,9 @@ impl HttpDownloader {
         headers: &[(String, String)],
         cookies: Option<&[String]>,
         checksum: Option<&ExpectedChecksum>,
-        #[cfg(feature = "recursive-http")]
-        redirect_scope: Option<crate::http::crawl::RedirectScope>,
+        #[cfg(feature = "recursive-http")] redirect_scope: Option<
+            crate::http::crawl::RedirectScope,
+        >,
         cancel_token: CancellationToken,
         progress_callback: F,
     ) -> Result<PathBuf>
@@ -520,9 +527,7 @@ impl HttpDownloader {
                 }
                 Err(e) => {
                     // Keep .part file for potential resume
-                    if e.is_retryable()
-                        && self.retry_policy.should_retry(stream_attempt, &e)
-                    {
+                    if e.is_retryable() && self.retry_policy.should_retry(stream_attempt, &e) {
                         stream_attempt += 1;
                         let delay = self.retry_policy.delay_for_attempt(stream_attempt - 1);
                         if supports_range {
@@ -730,8 +735,9 @@ impl HttpDownloader {
         headers: &[(String, String)],
         cookies: Option<&[String]>,
         checksum: Option<&ExpectedChecksum>,
-        #[cfg(feature = "recursive-http")]
-        redirect_scope: Option<crate::http::crawl::RedirectScope>,
+        #[cfg(feature = "recursive-http")] redirect_scope: Option<
+            crate::http::crawl::RedirectScope,
+        >,
         max_connections: usize,
         min_segment_size: u64,
         cancel_token: CancellationToken,

--- a/src/http/segment.rs
+++ b/src/http/segment.rs
@@ -240,8 +240,7 @@ impl SegmentedDownload {
         headers: &[(String, String)],
         max_connections: usize,
         retry_policy: &RetryPolicy,
-        #[cfg(feature = "recursive-http")]
-        redirect_scope: Option<super::crawl::RedirectScope>,
+        #[cfg(feature = "recursive-http")] redirect_scope: Option<super::crawl::RedirectScope>,
         cancel_token: CancellationToken,
         progress_callback: F,
     ) -> Result<()>

--- a/src/priority_queue.rs
+++ b/src/priority_queue.rs
@@ -7,7 +7,7 @@
 use crate::protocol::DownloadId;
 use parking_lot::Mutex;
 use std::collections::{BinaryHeap, HashMap};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
 
@@ -74,6 +74,8 @@ struct PriorityQueueInner {
 pub struct PriorityQueue {
     /// Semaphore for limiting concurrent downloads
     semaphore: Arc<Semaphore>,
+    /// Current concurrency ceiling for new acquisitions.
+    max_concurrent: AtomicUsize,
     /// Internal queue state
     inner: Mutex<PriorityQueueInner>,
     /// Sequence counter for FIFO ordering
@@ -87,6 +89,7 @@ impl PriorityQueue {
     pub fn new(max_concurrent: usize) -> Arc<Self> {
         Arc::new(Self {
             semaphore: Arc::new(Semaphore::new(max_concurrent)),
+            max_concurrent: AtomicUsize::new(max_concurrent),
             inner: Mutex::new(PriorityQueueInner {
                 waiting: BinaryHeap::new(),
                 active: HashMap::new(),
@@ -134,7 +137,9 @@ impl PriorityQueue {
             {
                 let inner = self.inner.lock();
                 if let Some(next) = inner.waiting.peek() {
-                    if next.id == id {
+                    if next.id == id
+                        && inner.active.len() < self.max_concurrent.load(Ordering::Relaxed)
+                    {
                         // We're next, try to acquire semaphore
                         drop(inner); // Release lock before async operation
 
@@ -188,6 +193,9 @@ impl PriorityQueue {
         priority: DownloadPriority,
     ) -> Option<PriorityPermit> {
         let mut inner = self.inner.lock();
+        if inner.active.len() >= self.max_concurrent.load(Ordering::Relaxed) {
+            return None;
+        }
 
         // Check if there are higher priority downloads waiting
         if let Some(next) = inner.waiting.peek() {
@@ -270,6 +278,15 @@ impl PriorityQueue {
             .get(&id)
             .or_else(|| inner.active.get(&id))
             .copied()
+    }
+
+    /// Update the concurrency ceiling for future acquisitions.
+    pub fn set_max_concurrent(&self, max_concurrent: usize) {
+        let previous = self.max_concurrent.swap(max_concurrent, Ordering::Relaxed);
+        if max_concurrent > previous {
+            self.semaphore.add_permits(max_concurrent - previous);
+        }
+        self.notify.notify_waiters();
     }
 
     /// Get the number of active downloads

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -10,9 +10,9 @@ pub(crate) mod sqlite;
 pub use sqlite::SqliteStorage;
 
 use crate::error::Result;
-use crate::types::{DownloadId, DownloadStatus};
 #[cfg(feature = "recursive-http")]
 use crate::types::TrackedRecursiveJob;
+use crate::types::{DownloadId, DownloadStatus};
 use async_trait::async_trait;
 use std::collections::HashMap;
 

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -4,11 +4,11 @@
 
 use super::{Segment, SegmentState, Storage};
 use crate::error::{EngineError, Result};
+#[cfg(feature = "recursive-http")]
+use crate::types::TrackedRecursiveJob;
 use crate::types::{
     DownloadId, DownloadKind, DownloadMetadata, DownloadProgress, DownloadState, DownloadStatus,
 };
-#[cfg(feature = "recursive-http")]
-use crate::types::TrackedRecursiveJob;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection, OptionalExtension};
@@ -682,8 +682,9 @@ impl Storage for SqliteStorage {
 
         tokio::task::spawn_blocking(move || -> Result<()> {
             let conn = conn.blocking_lock();
-            let child_ids_json = serde_json::to_string(&job.child_ids)
-                .map_err(|e| EngineError::Database(format!("Failed to serialize child ids: {}", e)))?;
+            let child_ids_json = serde_json::to_string(&job.child_ids).map_err(|e| {
+                EngineError::Database(format!("Failed to serialize child ids: {}", e))
+            })?;
             conn.execute(
                 r#"
                 INSERT INTO recursive_jobs (id, root_url, child_ids_json, created_at)

--- a/src/torrent/mod.rs
+++ b/src/torrent/mod.rs
@@ -64,6 +64,10 @@ use std::time::{Duration, Instant};
 use parking_lot::RwLock;
 use tokio::sync::{broadcast, Semaphore};
 
+use crate::config::{
+    EncryptionConfig as EngineEncryptionConfig, EncryptionPolicy as EngineEncryptionPolicy,
+    TransportPolicy, WebSeedConfig as EngineWebSeedConfig,
+};
 use crate::error::Result;
 use crate::types::{DownloadEvent, DownloadId, DownloadProgress};
 use pex::parse_extension_handshake;
@@ -232,6 +236,14 @@ pub struct TorrentDownloader {
     /// Set at construction for .torrent files, or when metadata is
     /// fetched for magnet links.
     raw_torrent_data: RwLock<Option<Vec<u8>>>,
+    /// Piece-selection preferences that may arrive before metadata is available.
+    pending_selected_files: RwLock<Option<Vec<usize>>>,
+    pending_sequential: RwLock<Option<bool>>,
+    /// Per-download transport and protocol settings derived from EngineConfig.
+    webseed_config: RwLock<EngineWebSeedConfig>,
+    mse_config: RwLock<MseConfig>,
+    transport_policy: RwLock<TransportPolicy>,
+    tcp_fallback: AtomicBool,
     /// uTP multiplexer for UDP-based peer connections (BEP 29).
     /// Initialized in `start()` when `config.enable_utp` is true.
     utp_mux: RwLock<Option<Arc<UtpMux>>>,
@@ -328,6 +340,15 @@ impl TorrentDownloader {
             #[cfg(feature = "http")]
             webseed_task: RwLock::new(None),
             raw_torrent_data: RwLock::new(None),
+            pending_selected_files: RwLock::new(None),
+            pending_sequential: RwLock::new(None),
+            webseed_config: RwLock::new(EngineWebSeedConfig::default()),
+            mse_config: RwLock::new(MseConfig {
+                policy: EncryptionPolicy::Disabled,
+                ..MseConfig::default()
+            }),
+            transport_policy: RwLock::new(TransportPolicy::PreferTcp),
+            tcp_fallback: AtomicBool::new(true),
             utp_mux: RwLock::new(None),
         })
     }
@@ -368,6 +389,15 @@ impl TorrentDownloader {
             #[cfg(feature = "http")]
             webseed_task: RwLock::new(None),
             raw_torrent_data: RwLock::new(None),
+            pending_selected_files: RwLock::new(None),
+            pending_sequential: RwLock::new(None),
+            webseed_config: RwLock::new(EngineWebSeedConfig::default()),
+            mse_config: RwLock::new(MseConfig {
+                policy: EncryptionPolicy::Disabled,
+                ..MseConfig::default()
+            }),
+            transport_policy: RwLock::new(TransportPolicy::PreferTcp),
+            tcp_fallback: AtomicBool::new(true),
             utp_mux: RwLock::new(None),
         })
     }
@@ -382,6 +412,7 @@ impl TorrentDownloader {
     /// Only pieces that contain data from the selected files will be downloaded.
     /// If `file_indices` is empty or None, all files will be downloaded.
     pub fn set_selected_files(&self, file_indices: Option<&[usize]>) {
+        *self.pending_selected_files.write() = file_indices.map(|indices| indices.to_vec());
         if let Some(ref pm) = *self.piece_manager.read() {
             pm.set_selected_files(file_indices);
         }
@@ -390,8 +421,47 @@ impl TorrentDownloader {
     /// Enable or disable sequential download mode.
     /// When enabled, pieces are downloaded in order for streaming support.
     pub fn set_sequential(&self, sequential: bool) {
+        *self.pending_sequential.write() = Some(sequential);
         if let Some(ref pm) = *self.piece_manager.read() {
             pm.set_sequential(sequential);
+        }
+    }
+
+    /// Override the webseed configuration for this download.
+    pub fn set_webseed_config(&self, config: EngineWebSeedConfig) {
+        *self.webseed_config.write() = config;
+    }
+
+    /// Override the MSE configuration for this download.
+    pub fn set_mse_config(&self, config: EngineEncryptionConfig) {
+        *self.mse_config.write() = MseConfig {
+            policy: match config.policy {
+                EngineEncryptionPolicy::Disabled => EncryptionPolicy::Disabled,
+                EngineEncryptionPolicy::Allowed => EncryptionPolicy::Allowed,
+                EngineEncryptionPolicy::Preferred => EncryptionPolicy::Preferred,
+                EngineEncryptionPolicy::Required => EncryptionPolicy::Required,
+            },
+            allow_plaintext: config.allow_plaintext,
+            allow_rc4: config.allow_rc4,
+            min_padding: config.min_padding,
+            max_padding: config.max_padding,
+        };
+    }
+
+    /// Override the transport policy for this download.
+    pub fn set_transport_policy(&self, policy: TransportPolicy, tcp_fallback: bool) {
+        *self.transport_policy.write() = policy;
+        self.tcp_fallback.store(tcp_fallback, Ordering::Relaxed);
+    }
+
+    fn apply_piece_manager_preferences(&self, piece_manager: &PieceManager) {
+        let selected_files = self.pending_selected_files.read().clone();
+        if let Some(selected_files) = selected_files.as_deref() {
+            piece_manager.set_selected_files(Some(selected_files));
+        }
+
+        if let Some(sequential) = *self.pending_sequential.read() {
+            piece_manager.set_sequential(sequential);
         }
     }
 
@@ -603,6 +673,12 @@ impl TorrentDownloader {
             return;
         }
 
+        let engine_webseed_config = self.webseed_config.read().clone();
+        if !engine_webseed_config.enabled {
+            tracing::debug!("Webseeds disabled for torrent {}", self.info_hash_hex());
+            return;
+        }
+
         tracing::info!(
             "Starting webseed downloads for torrent {} with {} seeds",
             self.info_hash_hex(),
@@ -610,7 +686,12 @@ impl TorrentDownloader {
         );
 
         // Create webseed manager
-        let config = WebSeedConfig::default();
+        let config = WebSeedConfig {
+            max_connections: engine_webseed_config.max_connections,
+            request_timeout: Duration::from_secs(engine_webseed_config.timeout_seconds),
+            max_failures: engine_webseed_config.max_failures,
+            ..WebSeedConfig::default()
+        };
         let (manager, mut event_rx) =
             match WebSeedManager::new(metainfo.clone(), piece_manager.clone(), config) {
                 Ok(result) => result,
@@ -1133,35 +1214,131 @@ impl TorrentDownloader {
         shared_stats: Arc<RwLock<HashMap<SocketAddr, PeerStats>>>,
         choking_decisions: Arc<RwLock<HashMap<SocketAddr, bool>>>,
     ) -> Result<()> {
-        // Connect to peer — try uTP first if available, fall back to TCP
+        // Connect to peer using the configured transport policy.
         let metadata_only = downloader.metadata_fetcher.is_some() && num_pieces == 0;
         let utp_mux = downloader.utp_mux.read().clone();
-        let mut conn = if let Some(ref mux) = utp_mux {
-            match mux.connect(addr).await {
-                Ok(socket) => {
-                    match PeerConnection::connect_utp(socket, info_hash, peer_id, num_pieces).await
-                    {
-                        Ok(c) => {
-                            tracing::info!("Connected to peer {} via uTP", addr);
-                            c
-                        }
-                        Err(e) => {
-                            tracing::debug!(
-                                "uTP handshake with {} failed: {}, falling back to TCP",
-                                addr,
-                                e
-                            );
-                            PeerConnection::connect(addr, info_hash, peer_id, num_pieces).await?
+        let transport_policy = *downloader.transport_policy.read();
+        let tcp_fallback = downloader.tcp_fallback.load(Ordering::Relaxed);
+        let mse_config = downloader.mse_config.read().clone();
+        let mut conn = match transport_policy {
+            TransportPolicy::TcpOnly => {
+                PeerConnection::connect_with_encryption(
+                    addr,
+                    info_hash,
+                    peer_id,
+                    num_pieces,
+                    Some(&mse_config),
+                )
+                .await?
+            }
+            TransportPolicy::PreferTcp => {
+                match PeerConnection::connect_with_encryption(
+                    addr,
+                    info_hash,
+                    peer_id,
+                    num_pieces,
+                    Some(&mse_config),
+                )
+                .await
+                {
+                    Ok(connection) => connection,
+                    Err(error) => {
+                        if let Some(ref mux) = utp_mux {
+                            if tcp_fallback {
+                                tracing::debug!(
+                                    "TCP connect to {} failed: {}, falling back to uTP",
+                                    addr,
+                                    error
+                                );
+                                let socket = mux.connect(addr).await?;
+                                PeerConnection::connect_utp(socket, info_hash, peer_id, num_pieces)
+                                    .await?
+                            } else {
+                                return Err(error);
+                            }
+                        } else {
+                            return Err(error);
                         }
                     }
                 }
-                Err(e) => {
-                    tracing::debug!("uTP connect to {} failed: {}, falling back to TCP", addr, e);
-                    PeerConnection::connect(addr, info_hash, peer_id, num_pieces).await?
+            }
+            TransportPolicy::UtpOnly | TransportPolicy::PreferUtp => {
+                if let Some(ref mux) = utp_mux {
+                    match mux.connect(addr).await {
+                        Ok(socket) => {
+                            match PeerConnection::connect_utp(
+                                socket, info_hash, peer_id, num_pieces,
+                            )
+                            .await
+                            {
+                                Ok(c) => {
+                                    tracing::info!("Connected to peer {} via uTP", addr);
+                                    c
+                                }
+                                Err(e) => {
+                                    if tcp_fallback && transport_policy != TransportPolicy::UtpOnly
+                                    {
+                                        tracing::debug!(
+                                            "uTP handshake with {} failed: {}, falling back to TCP",
+                                            addr,
+                                            e
+                                        );
+                                        PeerConnection::connect_with_encryption(
+                                            addr,
+                                            info_hash,
+                                            peer_id,
+                                            num_pieces,
+                                            Some(&mse_config),
+                                        )
+                                        .await?
+                                    } else {
+                                        return Err(e);
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            if tcp_fallback && transport_policy != TransportPolicy::UtpOnly {
+                                tracing::debug!(
+                                    "uTP connect to {} failed: {}, falling back to TCP",
+                                    addr,
+                                    e
+                                );
+                                PeerConnection::connect_with_encryption(
+                                    addr,
+                                    info_hash,
+                                    peer_id,
+                                    num_pieces,
+                                    Some(&mse_config),
+                                )
+                                .await?
+                            } else {
+                                return Err(crate::error::EngineError::network(
+                                    crate::error::NetworkErrorKind::Other,
+                                    format!("uTP connect failed: {}", e),
+                                ));
+                            }
+                        }
+                    }
+                } else if transport_policy == TransportPolicy::UtpOnly {
+                    return Err(crate::error::EngineError::network(
+                        crate::error::NetworkErrorKind::Other,
+                        format!(
+                            "uTP transport required for {} but no multiplexer is available",
+                            addr
+                        ),
+                    ));
+                } else {
+                    PeerConnection::connect_with_encryption(
+                        addr,
+                        info_hash,
+                        peer_id,
+                        num_pieces,
+                        Some(&mse_config),
+                    )
+                    .await?
                 }
             }
-        } else {
-            PeerConnection::connect(addr, info_hash, peer_id, num_pieces).await?
         };
         tracing::info!("Connected to peer {}", addr);
 
@@ -1481,6 +1658,7 @@ impl TorrentDownloader {
                                                         metainfo.clone(),
                                                         downloader.save_dir.clone(),
                                                     ));
+                                                    downloader.apply_piece_manager_preferences(&pm);
 
                                                     // Verify existing files (same as start() does for torrent files)
                                                     *downloader.state.write() =
@@ -1979,6 +2157,7 @@ impl TorrentDownloader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn test_torrent_config_default() {
@@ -1992,5 +2171,30 @@ mod tests {
     fn test_torrent_state() {
         assert_ne!(TorrentState::Downloading, TorrentState::Seeding);
         assert_eq!(TorrentState::Paused, TorrentState::Paused);
+    }
+
+    #[test]
+    fn test_magnet_preferences_are_retained_until_metadata_arrives() {
+        let magnet =
+            MagnetUri::parse("magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567")
+                .expect("valid magnet");
+        let (event_tx, _) = broadcast::channel(4);
+        let downloader = TorrentDownloader::from_magnet(
+            DownloadId::new(),
+            magnet,
+            PathBuf::from("."),
+            TorrentConfig::default(),
+            event_tx,
+        )
+        .expect("downloader");
+
+        downloader.set_selected_files(Some(&[1, 3]));
+        downloader.set_sequential(true);
+
+        assert_eq!(
+            downloader.pending_selected_files.read().clone(),
+            Some(vec![1, 3])
+        );
+        assert_eq!(*downloader.pending_sequential.read(), Some(true));
     }
 }

--- a/src/torrent/peer.rs
+++ b/src/torrent/peer.rs
@@ -553,9 +553,38 @@ impl PeerConnection {
 
         // Optionally perform MSE handshake
         let (stream, encrypted) = if let Some(config) = mse_config {
-            let peer_stream = connect_with_mse(tcp_stream, info_hash, config).await?;
-            let is_encrypted = peer_stream.is_encrypted();
-            (peer_stream, is_encrypted)
+            match connect_with_mse(tcp_stream, info_hash, config).await {
+                Ok(peer_stream) => {
+                    let is_encrypted = peer_stream.is_encrypted();
+                    (peer_stream, is_encrypted)
+                }
+                Err(error)
+                    if config.policy != super::mse::EncryptionPolicy::Required
+                        && config.allow_plaintext =>
+                {
+                    tracing::debug!(
+                        "MSE handshake with {} failed ({}), retrying plaintext",
+                        addr,
+                        error
+                    );
+                    let fallback_stream = timeout(PEER_CONNECT_TIMEOUT, TcpStream::connect(addr))
+                        .await
+                        .map_err(|_| {
+                            EngineError::network(
+                                NetworkErrorKind::Timeout,
+                                "Peer connection timeout",
+                            )
+                        })?
+                        .map_err(|e| {
+                            EngineError::network(
+                                NetworkErrorKind::ConnectionRefused,
+                                format!("Failed to connect: {}", e),
+                            )
+                        })?;
+                    (PeerStream::Plain(fallback_stream), false)
+                }
+                Err(error) => return Err(error),
+            }
         } else {
             (PeerStream::Plain(tcp_stream), false)
         };

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -129,7 +129,10 @@ fn assert_all_progress_invariants(progress_events: &[DownloadProgress]) {
 }
 
 #[cfg(feature = "recursive-http")]
-async fn wait_for_downloads_to_complete(engine: &std::sync::Arc<DownloadEngine>, ids: &[gosh_dl::DownloadId]) {
+async fn wait_for_downloads_to_complete(
+    engine: &std::sync::Arc<DownloadEngine>,
+    ids: &[gosh_dl::DownloadId],
+) {
     timeout(Duration::from_secs(10), async {
         loop {
             let statuses = ids
@@ -421,7 +424,9 @@ async fn test_recursive_download_downloads_nested_files() {
         .respond_with(
             ResponseTemplate::new(200)
                 .insert_header("Content-Type", "text/html")
-                .set_body_string(r#"<html><body><a href="app.tar.gz">app.tar.gz</a></body></html>"#),
+                .set_body_string(
+                    r#"<html><body><a href="app.tar.gz">app.tar.gz</a></body></html>"#,
+                ),
         )
         .mount(&mock_server)
         .await;
@@ -595,10 +600,10 @@ async fn test_recursive_child_download_rejects_redirect_out_of_scope() {
 
     Mock::given(method("HEAD"))
         .and(path("/pub/file.txt"))
-        .respond_with(
-            ResponseTemplate::new(302)
-                .insert_header("Location", format!("{}/elsewhere/file.txt", mock_server.uri())),
-        )
+        .respond_with(ResponseTemplate::new(302).insert_header(
+            "Location",
+            format!("{}/elsewhere/file.txt", mock_server.uri()),
+        ))
         .mount(&mock_server)
         .await;
 
@@ -665,10 +670,10 @@ async fn test_recursive_without_fail_fast_allows_other_children_to_finish() {
 
     Mock::given(method("HEAD"))
         .and(path("/pub/bad.txt"))
-        .respond_with(
-            ResponseTemplate::new(302)
-                .insert_header("Location", format!("{}/elsewhere/bad.txt", mock_server.uri())),
-        )
+        .respond_with(ResponseTemplate::new(302).insert_header(
+            "Location",
+            format!("{}/elsewhere/bad.txt", mock_server.uri()),
+        ))
         .mount(&mock_server)
         .await;
 
@@ -767,10 +772,10 @@ async fn test_recursive_fail_fast_stops_other_children() {
 
     Mock::given(method("HEAD"))
         .and(path("/pub/bad.txt"))
-        .respond_with(
-            ResponseTemplate::new(302)
-                .insert_header("Location", format!("{}/elsewhere/bad.txt", mock_server.uri())),
-        )
+        .respond_with(ResponseTemplate::new(302).insert_header(
+            "Location",
+            format!("{}/elsewhere/bad.txt", mock_server.uri()),
+        ))
         .mount(&mock_server)
         .await;
 
@@ -828,7 +833,11 @@ async fn test_recursive_fail_fast_stops_other_children() {
         DownloadState::Error { .. }
     ));
     match engine.status(slow_id).expect("slow child status").state {
-        DownloadState::Error { kind, message, retryable } => {
+        DownloadState::Error {
+            kind,
+            message,
+            retryable,
+        } => {
             assert_eq!(kind, "RecursiveFailFast");
             assert!(
                 message.contains(&bad_id.to_string()),
@@ -881,10 +890,10 @@ async fn test_recursive_child_redirect_scope_persists_across_restart() {
 
     Mock::given(method("GET"))
         .and(path("/pub/file.txt"))
-        .respond_with(
-            ResponseTemplate::new(302)
-                .insert_header("Location", format!("{}/elsewhere/file.txt", mock_server.uri())),
-        )
+        .respond_with(ResponseTemplate::new(302).insert_header(
+            "Location",
+            format!("{}/elsewhere/file.txt", mock_server.uri()),
+        ))
         .mount(&mock_server)
         .await;
 
@@ -1033,7 +1042,11 @@ async fn test_tracked_recursive_jobs_persist_across_restart() {
     let resumed_engine =
         create_persistent_test_engine(&temp_dir, "tracked-recursive.sqlite", 4).await;
     let jobs = resumed_engine.list_recursive_jobs();
-    assert_eq!(jobs.len(), 1, "one tracked recursive job should be restored");
+    assert_eq!(
+        jobs.len(),
+        1,
+        "one tracked recursive job should be restored"
+    );
 
     let tracked_job = &jobs[0];
     assert_eq!(tracked_job.root_url, root_url);
@@ -2931,7 +2944,11 @@ async fn test_retry_exhaustion_reports_retryable_failure() {
 
     assert!(!completed, "Should not complete when server returns 500");
     let (error_msg, retryable) = failed.expect("Should receive Failed event");
-    assert!(retryable, "500 errors should be retryable, got: {}", error_msg);
+    assert!(
+        retryable,
+        "500 errors should be retryable, got: {}",
+        error_msg
+    );
 
     // Verify the engine status also reflects retryable
     let status = engine.status(id).expect("Should have status");
@@ -3110,7 +3127,10 @@ async fn test_etag_change_between_resume_attempts_restarts_from_zero() {
 
     let (completed, _failed, progress_events) = wait_for_terminal(&mut events, id, 15).await;
 
-    assert!(completed, "Should complete with new content after ETag change");
+    assert!(
+        completed,
+        "Should complete with new content after ETag change"
+    );
     assert_all_progress_invariants(&progress_events);
 
     // Verify file has NEW content, not a mix
@@ -3118,7 +3138,10 @@ async fn test_etag_change_between_resume_attempts_restarts_from_zero() {
     let downloaded = tokio::fs::read(&downloaded_file)
         .await
         .expect("Failed to read downloaded file");
-    assert_eq!(downloaded, new_content, "File should contain new content, not old");
+    assert_eq!(
+        downloaded, new_content,
+        "File should contain new content, not old"
+    );
 
     engine.shutdown().await.ok();
 }


### PR DESCRIPTION
## What changed
- fixed HTTP limiter accounting so bandwidth limits charge exact byte counts
- wired per-download HTTP mirrors and `max_connections` into execution
- preserved priority, checksum, and mirrors across resume
- propagated live scheduler and config updates into queue concurrency and HTTP bandwidth limits
- wired torrent runtime config, webseed settings, transport policy, and encryption settings through the engine
- retained magnet file-selection and sequential preferences until metadata is available
- fixed a recursive HTTP deadlock caused by emitting recursive job updates while holding the download state write lock

## Why
Several features existed in configuration or metadata but were not actually wired into runtime behavior. The recursive HTTP path also had a lock-order regression that left child downloads stuck in `Queued`.

## Impact
- runtime config changes now affect live downloads as expected
- resume behavior preserves more user intent
- recursive HTTP child downloads no longer hang when state transitions emit parent-job updates
- torrent downloads honor more of the configured transport and runtime settings without regressing plaintext/TCP defaults

## Validation
- `cargo test`
- `cargo test --test torrent_integration_tests`
- `cargo test --features recursive-http --test torrent_integration_tests`
- `cargo test --features recursive-http`
