### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-11
+
 ### Added
 - Recursive HTTP directory mirroring behind the `recursive-http` feature flag
 - `discover_http_recursive()` and `add_http_recursive()` engine APIs
@@ -14,13 +16,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recursive parent job lifecycle APIs: `list_recursive_jobs()`, `recursive_job()`, `cancel_recursive_job()`, `remove_recursive_job()`, and `subscribe_recursive_jobs()`
 - Dedicated recursive parent event stream separate from `DownloadEvent`
 - SQLite schema v4 support for persisted tracked recursive jobs
+- Regression coverage for HTTP limiter accounting, mirror failover, magnet preference retention, live config updates, and recursive parent-job behavior
 
 ### Changed
 - Recursive HTTP child downloads now reuse the standard HTTP pipeline while carrying redirect-scope and fail-fast runtime metadata through persistence/restart
+- Runtime configuration updates now propagate to live HTTP bandwidth limits and download queue concurrency
+- Torrent downloads now derive runtime transport, webseed, and scheduling settings from `EngineConfig::torrent`
 
 ### Fixed
 - Recursive enqueue is now transactional: if child creation fails partway through, already-added children are rolled back instead of being left orphaned
 - Recursive redirect scope is enforced during discovery, child downloads, and resumed child downloads restored from storage
+- HTTP rate limiting now charges exact byte counts instead of incorrect fixed-size chunks
+- Per-download HTTP mirrors and `max_connections` are now wired into execution
+- Resume now preserves priority, checksum, and mirrors
+- Magnet `selected_files` and `sequential` preferences now persist until metadata is available
+- Torrent webseed, transport policy, and encryption settings are now wired through without regressing plaintext/TCP defaults
+- Recursive HTTP child downloads no longer deadlock in `Queued` during state-transition updates
 
 ### Documentation
 - Updated the README, technical spec, and recursive design/checklist docs to match the current shipped recursive feature set and remaining follow-up work
@@ -263,7 +274,8 @@ adds proper infrastructure, and restructures the public API.
 - Crash recovery and resume
 - Segment-level progress tracking for HTTP downloads
 
-[Unreleased]: https://github.com/goshitsarch-eng/gosh-dl/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/goshitsarch-eng/gosh-dl/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/goshitsarch-eng/gosh-dl/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/goshitsarch-eng/gosh-dl/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/goshitsarch-eng/gosh-dl/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/goshitsarch-eng/gosh-dl/compare/v0.2.9...v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "gosh-dl"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gosh-dl"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.85"
 description = "A fast, embeddable download engine for Rust. HTTP/HTTPS with multi-connection acceleration and full BitTorrent protocol support."

--- a/src/http/crawl.rs
+++ b/src/http/crawl.rs
@@ -768,7 +768,10 @@ mod tests {
 
         Mock::given(method("GET"))
             .and(path("/pub/"))
-            .and(header("user-agent", "gosh-dl/0.3.2"))
+            .and(header(
+                "user-agent",
+                format!("gosh-dl/{}", env!("CARGO_PKG_VERSION")).as_str(),
+            ))
             .respond_with(
                 ResponseTemplate::new(200)
                     .insert_header("Content-Type", "text/html")


### PR DESCRIPTION
## Summary
- release `gosh-dl` version `0.4.0`
- add the `0.4.0` changelog entry
- ship the runtime config, HTTP wiring, torrent config, and recursive HTTP fixes included on this branch

## Included work
- fixed HTTP limiter accounting to charge exact byte counts
- wired per-download HTTP mirrors and `max_connections`
- preserved priority, checksum, and mirrors across resume
- propagated live scheduler/config changes into queue concurrency and HTTP bandwidth limits
- wired torrent runtime config, webseed settings, transport policy, and encryption settings
- retained magnet file-selection and sequential preferences until metadata is available
- fixed the recursive HTTP queued-state deadlock
- updated recursive HTTP tests and persistence coverage
- updated release metadata for `v0.4.0`

## Validation
- `cargo test`
- `cargo test --features recursive-http`

## Tag
- `v0.4.0`
